### PR TITLE
allow use for 'all'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,9 +74,9 @@ function buildMiddlewares (routeObject) {
       throw new Error("" + name + " is a required configuration");
     }
 
-    if (
-      middlewareObject.include === "all" ||
-      (middlewareObject.include && middlewareObject.include.indexOf(routeObject.method) >= 0) ||
+    if ((middlewareObject.include &&
+      (middlewareObject.include.indexOf("all") ||
+      middlewareObject.include.indexOf(routeObject.method) >= 0)) ||
       routeObject.hasOwnProperty(name)
     ) {
       var routeMiddleware = logger(name, middlewareObject.generator(routeObject[name]));

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,19 @@ var logger = require("./logger");
 var middlewares = [];
 
 /**
+ * Check if a middleware should be included
+ * @param {Object} routeObject       the route object
+ * @param {Object} middlewareObject  the middleware object
+ * @returns {Boolean} wether or not the middleware should be included
+ */
+function shouldAddMiddleware(routeObject, middlewareObject) {
+  return middlewareObject.include && (
+    middlewareObject.include.indexOf("all") >= 0 ||
+    middlewareObject.include.indexOf(routeObject.method) >= 0
+  );
+}
+
+/**
  * add a middleware to run through
  * @param {Function} middlewareObject             function which takes a configuration object
  * @param {String}   middlewareObject.name        name of midleware to match route object keys
@@ -74,13 +87,11 @@ function buildMiddlewares (routeObject) {
       throw new Error("" + name + " is a required configuration");
     }
 
-    if ((middlewareObject.include &&
-      (middlewareObject.include.indexOf("all") ||
-      middlewareObject.include.indexOf(routeObject.method) >= 0)) ||
-      routeObject.hasOwnProperty(name)
-    ) {
-      var routeMiddleware = logger(name, middlewareObject.generator(routeObject[name]));
-      routeMiddlewares.push(routeMiddleware);
+    if (shouldAddMiddleware(routeObject, middlewareObject) || routeObject.hasOwnProperty(name)) {
+      [].concat(routeObject[name]).forEach(function(value) {
+        var routeMiddleware = logger(name, middlewareObject.generator(value));
+        routeMiddlewares.push(routeMiddleware);
+      });
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-route-builder",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Build express routes all easy like",
   "main": "index.js",
   "repository": {

--- a/test/index.js
+++ b/test/index.js
@@ -104,6 +104,28 @@ describe("express-route-buidler", function () {
       expect(mockReq.pagination).to.equal("pagination");
       expect(mockReq.authorization).to.equal(route.authorization);
     });
+
+    it("should build an array of route handlers where the route object value is an array", function () {
+      var count = 0;
+
+      expressRouteBuilder.setMiddlewares([
+        {
+          name: "rawHandler",
+          include: "all",
+          generator: function () {
+            count += 1;
+          }
+        }
+      ]);
+
+      expressRouteBuilder.buildMiddlewares({
+        method: "get",
+        path: "/fish",
+        rawHandler: ["1", "2", "3", "4"]
+      });
+
+      expect(count).to.equal(4);
+    });
   });
 
   describe("buildRouter", function () {


### PR DESCRIPTION
Since the `include` attribute is automatically converted to an array, comparing with `===` will return `false` if the `include` attribute is set to "all". This fixes that by checking if "all" is within the array.
